### PR TITLE
fix typo of client-configuration-consumer.md

### DIFF
--- a/static/reference/next/client/client-configuration-consumer.md
+++ b/static/reference/next/client/client-configuration-consumer.md
@@ -37,7 +37,7 @@ A longer ack group time is more efficient at the expense of a slight increase in
 **Default**: `100000`
 
 ### autoAckOldestChunkedMessageOnQueueFull
-Whether to automatically acknowledge pending chunked messages when the threashold of `maxPendingChunkedMessage` is reached. If set to `false`, these messages will be redelivered by their broker.
+Whether to automatically acknowledge pending chunked messages when the threshold of `maxPendingChunkedMessage` is reached. If set to `false`, these messages will be redelivered by their broker.
 
 **Type**: `boolean`
 
@@ -136,7 +136,7 @@ This setting reduces the receiver queue size for individual partitions if the to
 **Default**: `50000`
 
 ### negativeAckRedeliveryBackoff
-Interface for custom message is negativeAcked policy. You can specify `RedeliveryBackoff` for aconsumer.
+Interface for custom message is negativeAcked policy. You can specify `RedeliveryBackoff` for a consumer.
 
 **Type**: `org.apache.pulsar.client.api.RedeliveryBackoff`
 


### PR DESCRIPTION
### Documentation
fix typo of client-configuration-consumer.md, please check.

![image](https://user-images.githubusercontent.com/25130182/227116919-425edd35-97c8-473a-8500-f8195b75faeb.png)


- [x] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `./preview.sh` at root path) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
